### PR TITLE
Add a "listening on port..." message

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,9 @@ monitor.on('data', function(data) {
 
 app.use(express.static(__dirname + '/public'));
 
-server.listen(parseInt(process.argv[2]) || 3000);
+var port = parseInt(process.argv[2]) || 3000;
+server.listen(port);
+console.log("Mintr is listening on port " + port);
 
 var sockets = {};
 


### PR DESCRIPTION
When I first loaded up Mintr, I thought it was still loading because I didn't see any console output. This message helps clarify that Mintr is up and running.
